### PR TITLE
Avoid KeyError if transducer is missing transducer_params_wideband, add enumerate for idx value

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,154 @@
+# Byte-compiled / optimized / DLL files
+__pycache__/
+*.py[cod]
+*$py.class
+
+# C extensions
+*.so
+
+# Distribution / packaging
+.Python
+build/
+develop-eggs/
+dist/
+downloads/
+eggs/
+.eggs/
+lib/
+lib64/
+parts/
+sdist/
+var/
+wheels/
+*.egg-info/
+.installed.cfg
+*.egg
+MANIFEST
+
+# PyInstaller
+#  Usually these files are written by a python script from a template
+#  before PyInstaller builds the exe, so as to inject date/other infos into it.
+*.manifest
+*.spec
+
+# Installer logs
+pip-log.txt
+pip-delete-this-directory.txt
+
+# Unit test / coverage reports
+htmlcov/
+.tox/
+.coverage
+.coverage.*
+.cache
+nosetests.xml
+coverage.xml
+*.cover
+.hypothesis/
+
+# Translations
+*.mo
+*.pot
+
+# Django stuff:
+*.log
+.static_storage/
+.media/
+local_settings.py
+
+# Flask stuff:
+instance/
+.webassets-cache
+
+# Scrapy stuff:
+.scrapy
+
+# Sphinx documentation
+docs/_build/
+
+# PyBuilder
+target/
+
+# Jupyter Notebook
+.ipynb_checkpoints
+
+# pyenv
+.python-version
+
+# celery beat schedule file
+celerybeat-schedule
+
+# SageMath parsed files
+*.sage.py
+
+# Environments
+.env
+.venv
+env/
+venv/
+ENV/
+env.bak/
+venv.bak/
+
+# Spyder project settings
+.spyderproject
+.spyproject
+
+# Rope project settings
+.ropeproject
+
+# mkdocs documentation
+/site
+
+# mypy
+.mypy_cache/
+
+#  Acoustic Data Files
+*.bot
+*.raw
+*.idx
+*.out
+*.evi
+
+# Instrument data directories in examples/data
+/examples/data/*/
+
+#  MATLAB data files
+*.mat
+
+#  chuck's IDE
+.idea/
+*.zip
+
+# Mac .DS_Store files
+.DS_Store
+*.m
+examples/python code/rick_test.py
+*.csv
+examples/rht_debug.py
+test/data
+test/ek80_sector_change_test.py
+test/Ibrahim_test.py
+test/misc tests/ek60_multiple_pulse_length_test.py
+test/misc tests/
+test/create_test_data_snippets.py
+test/compare_main_vs_RHT-EK80.py
+test/create_pickles.py
+.vscode/
+test/evl_test.py
+test/fix_z_offset_error.py
+test/grid_test.py
+test/knut_test.py
+test/knut_test2.py
+test/plot_heave_data.py
+test/test_resample.py
+test/test_resample2.py
+echolab2/instruments/resources/regrid.py
+echolab2/instruments/resources/regrid_orig.py
+echolab2/instruments/resources/version 1.01 config header with bb cal.txt
+echolab2/instruments/resources/version 1.23 config header no bb cal.txt
+echolab2/processing/afsc_bot_detector_nate.py
+echolab2/processing/processed_data_MS2.py
+examples/plot_single_ping_ES60.py
+examples/not_updated/read_out.py
+test/ek80_z_offset_bug_test_2.py

--- a/echolab2/instruments/util/simrad_parsers.py
+++ b/echolab2/instruments/util/simrad_parsers.py
@@ -1266,8 +1266,8 @@ class SimradXMLParser(_SimradDatagramParser):
 
                             # Unpack the wideband configuration data
                             packed_params = {}
-                            if chan_data['transducer_params_wideband']:
-                                for idx, freq in chan_data['transducer_params_wideband']['frequency']:
+                            if 'transducer_params_wideband' in chan_data:
+                                for idx, freq in enumerate(chan_data['transducer_params_wideband']['frequency']):
                                     packed_params[freq] = {'gain':chan_data['transducer_params_wideband']['gain'][idx],
                                             'beam_width_alongship':chan_data['transducer_params_wideband']['beam_width_alongship'][idx],
                                             'beam_width_athwartship':chan_data['transducer_params_wideband']['beam_width_athwartship'][idx],


### PR DESCRIPTION
Tiny fixes on two lines. First, xml _pack_contents throws a TypeError and interrupts process if a channel config is missing the transducer_params_wideband key: 
```   
   1267                             # Unpack the wideband configuration data
   1268                             packed_params = {}
-> 1269                             if chan_data['transducer_params_wideband']:
   1270                                 for idx, freq in enumerate(chan_data['transducer_params_wideband']['frequency']):
   1271                                     packed_params[freq] = {'gain':chan_data['transducer_params_wideband']['gain'][idx],

KeyError: 'transducer_params_wideband'
```

Second, where transducer_params_wideband does exist, the return is a 1-by array, so throws a TypeError:

```
   1268                             packed_params = {}
   1269                             if chan_data['transducer_params_wideband']:
-> 1270                                 for idx, freq in chan_data['transducer_params_wideband']['frequency']:
   1271                                     packed_params[freq] = {'gain':chan_data['transducer_params_wideband']['gain'][idx],
   1272                                             'beam_width_alongship':chan_data['transducer_params_wideband']['beam_width_alongship'][idx],

TypeError: cannot unpack non-iterable numpy.float32 object
```