### PR TITLE
Svf

### DIFF
--- a/echolab2/instruments/EK80.py
+++ b/echolab2/instruments/EK80.py
@@ -3265,20 +3265,17 @@ class raw_data(ping_data):
         psi_m = compute_psi_fm(10**(calibration.equivalent_beam_angle/10),f_nom,calibration.frequency_fft)
         lambda_m =   1470 /  calibration.frequency_fft#cal_objects_xml[chan].sound_speed /  cal_objects_xml[chan].frequency
         g_m = 10**(calibration.gain_fft/10)
-        
         svf_data = []
+        
+        y_pc_nu = simrad_signal_proc.pulse_compression(self,calibration=calibration)
+        y_pc_n = np.mean(y_pc_nu,axis=2)
+        r_n = get_range_vector(self)  
+        y_pc_s_n = simrad_signal_proc.calcPulseCompSphericalSpread(y_pc_n, r_n)
+
         for ping_no in return_indices:
-            y_rx_nu = self.complex[ping_no]
-            y_rx_nu = np.array([np.array([k[0] for k in y_rx_nu]), np.array([k[1] for k in y_rx_nu]),np.array([k[2] for k in y_rx_nu]),np.array([k[3] for k in y_rx_nu])])
-            y_pc_nu = simrad_signal_proc.pulse_compression(self,calibration=calibration)
-            y_pc_n = np.mean(y_pc_nu,axis=2)
-
-            r_n = get_range_vector(self)            
-            y_pc_s_n = simrad_signal_proc.calcPulseCompSphericalSpread(y_pc_n, r_n)
             y_mf_auto_n =  simrad_signal_proc.calcAutoCorrelation(tx_data[ping_no])
 
             y_mf_auto_n =  simrad_signal_proc.calcAutoCorrelation(tx_data[ping_no])
-
             
             Y_pc_v_m_n, Y_mf_auto_m, Y_tilde_pc_v_m_n, svf_range = simrad_signal_proc.calc_DFT_for_Sv(calibration,
                 y_pc_s_n[ping_no], w_tilde_i[ping_no], y_mf_auto_n, N_w[ping_no], r_n, step=min(range(len(r_n)), key=lambda i: abs(r_n[i]-step))+1)

--- a/echolab2/instruments/EK80.py
+++ b/echolab2/instruments/EK80.py
@@ -3299,6 +3299,7 @@ class raw_data(ping_data):
         setattr(p_data, 'sample_thickness', svf_range[1]-svf_range[0])
         setattr(p_data, 'range', svf_range)
         p_data.add_data_attribute('Svf', p_data.data)
+        p_data.is_log = True
         setattr(p_data, 'frequency', calibration.frequency_fft)
 
         delattr(calibration, 'frequency_fft')

--- a/echolab2/instruments/EK80.py
+++ b/echolab2/instruments/EK80.py
@@ -3174,6 +3174,11 @@ class raw_data(ping_data):
 
 
     def get_Svf(self, calibration, step=0.5, frequency_resolution=None):
+        '''
+        step: vertical window step in meters. Default is 0.5 m
+
+        frequency_resolution : frequency resolution of the output data in Hz
+        '''
         
         def compute_absorption_fm(data, f_m):
 

--- a/echolab2/instruments/echosounder.py
+++ b/echolab2/instruments/echosounder.py
@@ -1080,11 +1080,11 @@ def _filter_channel(chan, raw_obj, channels, frequencies,data_type):
     return_chan = False
     if channels is None and frequencies is None:
         return_chan = True
-    elif channels is None and raw_obj.get_frequency() in frequencies:
+    elif channels is None and raw_obj.configuration[0]['transducer_frequency'] in frequencies:
         return_chan = True
     elif frequencies is None and chan in channels:
         return_chan = True
-    elif raw_obj.get_frequency() in frequencies and chan in channels:
+    elif raw_obj.configuration[0]['transducer_frequency'] in frequencies and chan in channels:
         return_chan = True
     
     if (data_type=='Svf') and (hasattr(raw_obj,'complex') is False):

--- a/echolab2/instruments/echosounder.py
+++ b/echolab2/instruments/echosounder.py
@@ -395,7 +395,6 @@ def get_calibration_from_xml(data_object,xml_files,calibrations = None):
         # Read the calibration file
         cal = EK80.ek80_calibration()
         cal.read_xml_file(file)
-
         # Get the channel name from the calibration file and find the corresponding channel_id in the data_object
         try: # If the channel ends in a number, include it in the channel ID
             int(cal.channel_name.split('-')[-1])
@@ -439,21 +438,18 @@ def get_calibration_from_xml(data_object,xml_files,calibrations = None):
                                 attr = 'gain_fm'
                             current_frequency, current_gain = cal.frequency_fm, getattr(cal,attr)
 
-                        
                         # If the frequency/attribute is not an array (CW data), make it an array
-                        if ~isinstance(current_frequency,np.ndarray):
+                        if not isinstance(current_frequency,np.ndarray):
                             current_frequency = np.array([current_frequency])
-                        if ~isinstance(current_gain,np.ndarray):
+
+                        if not isinstance(current_gain,np.ndarray):
                             current_gain = np.array([current_gain])
-                        
+                            
                         # If the merged frequency array is empty, just add the current frequency array to it
                         if merged_frequency.size==0:
                             merged_frequency = current_frequency
                         else: # otherwise append the current frequency array to the merged frequency array and select only the unique values
-                            if cal.pulse_form == 0:
-                                merged_frequency = np.unique(np.concatenate((merged_frequency,current_frequency),0))
-                            else:
-                                merged_frequency = np.unique(np.concatenate((merged_frequency,current_frequency),1))
+                            merged_frequency = np.unique(np.concatenate((merged_frequency,current_frequency),0))
                         
                         # Append the current frequency and attribute values to the all frequency and attribute arrays
                         full_frequencies = np.append(full_frequencies,current_frequency)

--- a/echolab2/instruments/echosounder.py
+++ b/echolab2/instruments/echosounder.py
@@ -963,6 +963,13 @@ def get_angles(data_object, **kwargs):
     return _get_processed_data(data_object, 'angles', **kwargs)
 
 
+def get_Svf(data_object, calibration, **kwargs):
+    '''
+    Calibration is required for Svf.
+    '''
+    
+    return _get_processed_data(data_object, 'Svf', calibration=calibration, **kwargs)
+
 def _get_processed_data(data_object, data_type, calibration=None,
         frequencies=None, channel_ids=None, heave_correct=False, **kwargs):
     '''_get_processed_data is an internal function that returns a dictionary,
@@ -982,7 +989,8 @@ def _get_processed_data(data_object, data_type, calibration=None,
         raw_obj = data_object.raw_data[chan][0]
 
         #  check if we're returning this channel
-        return_chan = _filter_channel(chan, raw_obj, channel_ids, frequencies)
+        return_chan = _filter_channel(chan, raw_obj, channel_ids, frequencies, data_type)
+
 
         # if we are, get all of the data
         if return_chan:
@@ -1007,6 +1015,8 @@ def _get_processed_data(data_object, data_type, calibration=None,
                 p_data = raw_obj.get_power(calibration=cal_obj, **kwargs)
             elif data_type == 'angles':
                 p_data = raw_obj.get_physical_angles(calibration=cal_obj, **kwargs)
+            elif data_type == 'Svf':
+               p_data = raw_obj.get_Svf(calibration=cal_obj, **kwargs)
 
             #  add the navigation and motion data - this takes the asynchronous NMEA
             #  and motion data and interpolates it onto the ping time axis and stores
@@ -1065,7 +1075,7 @@ def _get_processed_data(data_object, data_type, calibration=None,
     return data
 
 
-def _filter_channel(chan, raw_obj, channels, frequencies):
+def _filter_channel(chan, raw_obj, channels, frequencies,data_type):
 
     return_chan = False
     if channels is None and frequencies is None:
@@ -1076,6 +1086,9 @@ def _filter_channel(chan, raw_obj, channels, frequencies):
         return_chan = True
     elif raw_obj.get_frequency() in frequencies and chan in channels:
         return_chan = True
+    
+    if (data_type=='Svf') and (hasattr(raw_obj,'complex') is False):
+        return_chan = False # If we don't have complex we can't caluclate Svf
 
     return return_chan
 

--- a/echolab2/instruments/echosounder.py
+++ b/echolab2/instruments/echosounder.py
@@ -472,7 +472,10 @@ def get_calibration_from_xml(data_object,xml_files,calibrations = None):
                         merged_val=merged_val[0]
                     # Set the merged attribute values to the merged calibration object
                     merged_cal.__setattr__(attr,merged_val)
-
+                
+                if len(merged_frequency)>1:
+                    merged_cal.__setattr__('frequency_fm',merged_frequency)
+                    
                 # Assign the merged calibration to the channel in the calibrations dictionary
                 calibrations[chan] = merged_cal
             

--- a/echolab2/instruments/util/simrad_calibration.py
+++ b/echolab2/instruments/util/simrad_calibration.py
@@ -30,6 +30,7 @@
 
 import numpy as np
 import xml.etree.ElementTree as ET
+import xml.etree.ElementTree as ET
 
 class calibration(object):
     """
@@ -443,8 +444,14 @@ class calibration(object):
             param, value = parse_xml_param(tag,root.find('./Calibration/'+tag).text)
             setattr(self, param, value)
 
-        setattr(self, 'channel_name', root.find('./Calibration/Common/Transceiver/ChannelName').text)
+        # If we're FM, we're gonna add a _fm to the gain and frequency and provide the mean values for the original attributes
+        if self.pulse_form == 1:
+            setattr(self, 'gain_fm', self.gain)
+            setattr(self, 'frequency_fm', self.frequency)
+            setattr(self, 'frequency', (self.frequency_fm[0] + self.frequency_fm[-1]) / 2)
+            setattr(self, 'gain', np.interp(self.frequency, self.frequency_fm,self.gain_fm))
 
+        setattr(self, 'channel_name', root.find('./Calibration/Common/Transceiver/ChannelName').text)
             
     def get_attribute_from_raw(self, raw_data, param_name, return_indices=None):
         """get_attribute_from_raw gets an individual attribute using the data

--- a/echolab2/processing/integration.py
+++ b/echolab2/processing/integration.py
@@ -73,21 +73,27 @@ class results(object):
         self._iter_layer = 0
         
         self.grid = grid
-
-        self.mean_Sv = np.full((grid.n_intervals, grid.n_layers), np.nan)
-        self.nasc = np.full((grid.n_intervals, grid.n_layers), np.nan)
-        self.min_Sv = np.full((grid.n_intervals, grid.n_layers), np.nan)
-        self.max_Sv = np.full((grid.n_intervals, grid.n_layers), np.nan)
-        self.mean_height = np.full((grid.n_intervals, grid.n_layers), np.nan)
-        self.good_samples = np.full((grid.n_intervals, grid.n_layers), np.nan)
-        self.no_data_samples = np.full((grid.n_intervals, grid.n_layers), np.nan)
-        self.excluded_samples = np.full((grid.n_intervals, grid.n_layers), np.nan)
-        self.total_samples = np.full((grid.n_intervals, grid.n_layers), np.nan)
-        self.min_sv_threshold_applied = np.full((grid.n_intervals, grid.n_layers), np.nan)
-        self.max_sv_threshold_applied = np.full((grid.n_intervals, grid.n_layers), np.nan)
+        
+        
+        grid_shape = (grid.n_intervals, grid.n_layers)
+        if grid.grid_data:
+            if grid.grid_data.data.ndim > 2:
+                grid_shape = (grid.n_intervals, grid.n_layers,grid.grid_data.data.shape[-1])
+        
+        self.mean_Sv = np.full(grid_shape, np.nan)
+        self.nasc = np.full(grid_shape, np.nan)
+        self.min_Sv = np.full(grid_shape, np.nan)
+        self.max_Sv = np.full(grid_shape, np.nan)
+        self.mean_height = np.full(grid_shape, np.nan)
+        self.good_samples = np.full(grid_shape, np.nan)
+        self.no_data_samples = np.full(grid_shape, np.nan)
+        self.excluded_samples = np.full(grid_shape, np.nan)
+        self.total_samples = np.full(grid_shape, np.nan)
+        self.min_sv_threshold_applied = np.full(grid_shape, np.nan)
+        self.max_sv_threshold_applied = np.full(grid_shape, np.nan)
 #        self.thickness_mean = np.full((grid.n_intervals, grid.n_layers), np.nan)
-        self.exclude_below_line_mean = np.full((grid.n_intervals, grid.n_layers), np.nan)
-        self.exclude_above_line_mean = np.full((grid.n_intervals, grid.n_layers), np.nan)
+        self.exclude_below_line_mean = np.full(grid_shape, np.nan)
+        self.exclude_above_line_mean = np.full(grid_shape, np.nan)
 
     def export_to_csv(self, filename, output_empty_cells=False):
         
@@ -405,10 +411,10 @@ class integrator(object):
                 
                 #  Now compute the mean and some other bits
                 if np.nansum(cell_data_included) > 0:
-                    cell_mean_sv = np.nanmean(cell_data_included)
-                    cell_min_sv = np.nanmin(cell_data_included)
-                    cell_max_sv = np.nanmax(cell_data_included)
-                    if cell_mean_sv > 1e-100:
+                    cell_mean_sv = np.nanmean(cell_data_included,axis=0)
+                    cell_min_sv = np.nanmin(cell_data_included,axis=0)
+                    cell_max_sv = np.nanmax(cell_data_included,axis=0)
+                    if cell_mean_sv.any() > 1e-100:
                         cell_mean_Sv = 10.0 * np.log10(cell_mean_sv)
                         cell_max_Sv = 10.0 * np.log10(cell_max_sv)
                         cell_nasc = cell_mean_sv * cell_thickness * 4 * np.pi * 1852**2
@@ -416,7 +422,7 @@ class integrator(object):
                         cell_mean_Sv = -999
                         cell_max_Sv = -999
                         cell_nasc= 0
-                    if cell_min_sv > 1e-100:
+                    if cell_min_sv.any() > 1e-100:
                         cell_min_Sv = 10.0 * np.log10(cell_min_sv)
                     else:
                         cell_min_Sv = -999


### PR DESCRIPTION
@rhtowler I don't want to open a big bag of worms with this, but this is my first pass at getting Svf at all levels. It might make more sense if you want me to add this as a branch for now instead of pulling into main, but I wanted it to be somewhere that @AlexDeRobertis-NOAA can grab it and play around with the summer data. Bottom line is it works and doesn't disrupt anything else, with identical `echosounder` functionality.

- `simrad_calibration` had to be updated again to now add frequency_fm and gain_fm. This gets around any disruption to calculating Sv(t) the way it's always been.
- `simrad_signal_processing`: I just dumped in (with some minor changes) the rest of the required functions from the Calculation lib. This still needs to be optimized.
- `EK80`: I added the ping-by-ping loop for Svf here. This will need some cleaning, and for convenience I had to add in sub-functions for alpha, psi, and range, since this doesn't go through the usual get_sample_data path. Not efficient, but it works.
- `echosounder`: added the wrapper and minor changes to _get_processed_data and _filter_channels so that it doesn't get mad.

I still need to add comments, and I have an example notebook going. I'm also checking grid/integration.